### PR TITLE
Update OBS distribution targets and build configuration

### DIFF
--- a/.claude/work-state.md
+++ b/.claude/work-state.md
@@ -16,7 +16,7 @@ M8 완료 → M9 준비 (Widget System + System Tray)
 - [x] M8a-M8d: 가상 데스크톱, 멀티 모니터, Per-Screen 설정, Follow Active
 - [x] 멀티 배포판 패키징 인프라 구축
   - COPR (Fedora 42/43/Rawhide): 6/6 빌드 성공
-  - OBS (openSUSE Tumbleweed/Slowroll, Fedora, Debian 13, Ubuntu 25.04-26.04): 17/17 빌드 성공
+  - OBS (openSUSE Tumbleweed/Slowroll/Leap 16.0, Fedora 42/43/44/Rawhide, Debian 13, Ubuntu 25.04-26.04): 21/21 builds succeeded
   - Launchpad PPA (Ubuntu 25.10 questing, 26.04 resolute): Published
   - AUR: 기존 운영 유지
 - [x] 크로스 배포판 빌드 호환성

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Virtual desktop filtering: show windows from current desktop only, or all desktops with dimmed icons for other desktops
 - Fedora (COPR), openSUSE (OBS), Debian, and Ubuntu packaging support
 - Compile-time LayerShellQt API detection for cross-distribution compatibility
+- OBS build targets for Fedora 44 and openSUSE Leap 16.0
 
 ### Fixed
 
 - Build compatibility with LayerShellQt < 6.4 (Ubuntu 25.04, Debian 13)
 - Build compatibility with strict `QT_NO_CAST_FROM_ASCII` flag on non-Arch distributions
+- Fedora Rawhide OBS resolver preferences for current ICU and systemd packages
+- openSUSE Slowroll OBS support corrected to x86_64, matching upstream Slowroll architecture availability
+- openSUSE Leap 16.0 OBS compiler dependency aligned with Krema's GCC 13 minimum
 
 ## [0.7.0] - 2026-03-28
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ Krema brings back the beloved dock experience for KDE Plasma users who miss Latt
 | Distribution | Versions | Architectures |
 |---|---|---|
 | Arch Linux / Manjaro | Rolling | x86_64, aarch64 |
-| Fedora | 42, 43, Rawhide | x86_64, aarch64 |
-| openSUSE | Tumbleweed, Slowroll | x86_64, aarch64 |
+| Fedora | 42, 43, 44, Rawhide | x86_64, aarch64 |
+| openSUSE Tumbleweed | Rolling | x86_64, aarch64 |
+| openSUSE Slowroll | Rolling | x86_64 |
+| openSUSE Leap | 16.0 | x86_64, aarch64 |
 | Ubuntu | 25.04, 25.10, 26.04 | x86_64, aarch64 |
 | Debian | 13 (Trixie) | x86_64, aarch64 |
 
@@ -123,6 +125,11 @@ sudo zypper install krema
 
 # Slowroll
 sudo zypper addrepo https://download.opensuse.org/repositories/home:isac322/openSUSE_Slowroll/home:isac322.repo
+sudo zypper refresh
+sudo zypper install krema
+
+# Leap 16.0
+sudo zypper addrepo https://download.opensuse.org/repositories/home:isac322/openSUSE_Leap_16.0/home:isac322.repo
 sudo zypper refresh
 sudo zypper install krema
 ```

--- a/packaging/obs/apply-project-config.sh
+++ b/packaging/obs/apply-project-config.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project="${OBS_PROJECT:-home:isac322}"
+osc_bin="${OSC:-osc}"
+
+"${osc_bin}" api -X PUT -T "${script_dir}/project.meta.xml" "/source/${project}/_meta"
+"${osc_bin}" api -X PUT -T "${script_dir}/project.config" "/source/${project}/_config"
+"${osc_bin}" results "${project}" krema

--- a/packaging/obs/krema.spec
+++ b/packaging/obs/krema.spec
@@ -16,7 +16,7 @@ BuildRequires:  ninja
 %else
 BuildRequires:  ninja-build
 %endif
-BuildRequires:  gcc-c++ >= 14
+BuildRequires:  gcc-c++ >= 13
 BuildRequires:  extra-cmake-modules >= 6.0.0
 
 # Qt 6

--- a/packaging/obs/project.config
+++ b/packaging/obs/project.config
@@ -1,0 +1,27 @@
+# Resolve ambiguous dependencies for multi-distro builds
+
+# Fedora: system-logos and pinentry choices
+Prefer: fedora-logos
+Prefer: pinentry-qt
+
+# Fedora Rawhide: ICU soname and tmpfiles choices
+Prefer: libicu
+Prefer: systemd
+
+# Fedora 42: OpenCL and VPL choices
+Prefer: ocl-icd
+Prefer: oneVPL
+
+# Debian/Ubuntu: FFmpeg codec choices (needed by kpipewire/qt6multimedia)
+Prefer: libavformat61
+Prefer: libavcodec61
+Prefer: libavfilter10
+Prefer: libavformat-extra61
+Prefer: libavcodec-extra61
+Prefer: libavfilter-extra10
+Prefer: libavcodec62
+Prefer: libavformat62
+Prefer: libavfilter11
+Prefer: libavcodec-extra62
+Prefer: libavformat-extra62
+Prefer: libavfilter-extra11

--- a/packaging/obs/project.meta.xml
+++ b/packaging/obs/project.meta.xml
@@ -1,0 +1,59 @@
+<project name="home:isac322">
+  <title></title>
+  <description></description>
+  <person userid="isac322" role="maintainer"/>
+  <repository name="xUbuntu_26.04">
+    <path project="Ubuntu:26.04" repository="universe"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="xUbuntu_25.10">
+    <path project="Ubuntu:25.10" repository="universe"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="xUbuntu_25.04">
+    <path project="Ubuntu:25.04" repository="universe"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="openSUSE_Tumbleweed">
+    <path project="openSUSE:Factory" repository="snapshot"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="openSUSE_Slowroll">
+    <path project="openSUSE:Slowroll" repository="standard"/>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="openSUSE_Leap_16.0">
+    <path project="openSUSE:Leap:16.0" repository="standard"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="Fedora_Rawhide">
+    <path project="Fedora:Rawhide" repository="standard"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="Fedora_44">
+    <path project="Fedora:44" repository="standard"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="Fedora_43">
+    <path project="Fedora:43" repository="standard"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="Fedora_42">
+    <path project="Fedora:42" repository="standard"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="Debian_13">
+    <path project="Debian:13" repository="standard"/>
+    <arch>aarch64</arch>
+    <arch>x86_64</arch>
+  </repository>
+</project>


### PR DESCRIPTION
This PR updates the OBS packaging configuration for the current distribution matrix. It adds source-controlled OBS project metadata/config sync files, adds Fedora 44 and openSUSE Leap 16.0 as OBS targets, restricts openSUSE Slowroll to x86_64 to match upstream Slowroll architecture availability, and adds resolver preferences for Fedora Rawhide ICU/systemd choices. It also aligns the RPM spec compiler requirement with Krema’s documented GCC 13 minimum so openSUSE Leap 16.0 resolves successfully, and updates README, CHANGELOG, and work-state documentation with the verified OBS support matrix.

Verification:
- Applied the OBS project `_meta` and `_config` remotely with `packaging/obs/apply-project-config.sh`
- Uploaded the updated `packaging/obs/krema.spec` to OBS revision 18
- Ran `osc results -w home:isac322 krema` until completion
- Confirmed all 21 OBS targets succeeded, including Fedora 44, Fedora Rawhide, and openSUSE Leap 16.0 on x86_64/aarch64
- Ran local XML/spec/script checks and `git diff --check`