### PR TITLE
chore(tests): pin runtime image digests + add ghcr publish pipeline

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,6 +36,12 @@ obs-build-deb distro="Debian_13" arch="x86_64":
 docker-runtime-images target="all":
     tests/docker/build-images.sh {{target}}
 
+docker-runtime-update-digests target="all":
+    tests/docker/update-digests.sh {{target}}
+
+docker-runtime-publish target="all":
+    tests/docker/publish-images.sh {{target}}
+
 docker-runtime-smoke target package_dir:
     tests/docker/run-smoke.sh {{target}} {{package_dir}}
 

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -17,14 +17,27 @@ Use one host-side `kwin_wayland --virtual` compositor per smoke test and mount o
 - Debian 13
 - Ubuntu 25.04, 25.10, and 26.04
 
-The default image name is `krema/gui-runtime:<target-id>`.
+The default local image name is `krema/gui-runtime:<target-id>`. The published ghcr image is `ghcr.io/isac322/krema-gui-runtime-<target-id>:<tag>` (see [Publish to ghcr.io](#publish-to-ghcrio)).
 
-Slowroll uses `opensuse/tumbleweed:latest` as the container base because there
-is no official `opensuse/slowroll` runtime image. The Dockerfile disables the
-base repositories and enables the official Slowroll OSS and update repositories
-before installing runtime dependencies.
+Slowroll uses `opensuse/tumbleweed:latest` as the container base because there is no official `opensuse/slowroll` runtime image. The Dockerfile disables the base repositories and enables the official Slowroll OSS and update repositories before installing runtime dependencies. Slowroll's OBS packages are amd64-only, so the runtime image is also amd64-only.
 
-## Build images
+## Reproducibility and the base digest lockfile
+
+`targets.tsv` records a `base_digest` column with the sha256 manifest list digest of each `base_image`. The build scripts always pass `BASE_IMAGE` as `docker.io/<image>@<sha256:digest>` so rebuilding the same git revision pulls the exact same base layers — even when the upstream tag (for example `opensuse/tumbleweed:latest` or `fedora:rawhide`) has rolled forward.
+
+Refresh the lockfile when a base needs to be bumped:
+
+```bash
+DOCKER_HOST=tcp://localhost:2375 tests/docker/update-digests.sh all
+git add tests/docker/targets.tsv
+git commit -m "chore(tests): refresh runtime image base digests"
+```
+
+`update-digests.sh` calls `docker buildx imagetools inspect` and rewrites `targets.tsv` in place. Refreshing the digest is an explicit user action so that every reproducibility break is visible in `git log`.
+
+Tumbleweed and Slowroll share `opensuse/tumbleweed:latest` and therefore share a single manifest digest in the lockfile. The Slowroll-specific single-platform constraint is applied at publish time, not in the lockfile.
+
+## Build images locally
 
 ```bash
 DOCKER_HOST=tcp://localhost:2375 tests/docker/build-images.sh all
@@ -40,6 +53,89 @@ Build a specific architecture when using a multi-arch builder:
 
 ```bash
 KREMA_DOCKER_PLATFORM=linux/arm64 DOCKER_HOST=tcp://localhost:2375 tests/docker/build-images.sh ubuntu-26.04
+```
+
+If any `targets.tsv` row still has a `pending` `base_digest` value the build aborts with an instruction to run `update-digests.sh` first.
+
+## Publish to ghcr.io
+
+`tests/docker/publish-images.sh` builds each image with `docker buildx` from the locked base digest and pushes a multi-arch OCI manifest to `ghcr.io/<owner>/<repo-prefix>-<target_id>` (default: `ghcr.io/isac322/krema-gui-runtime-<target_id>`).
+
+Tag scheme:
+
+| Tag | Purpose |
+|---|---|
+| `<YYYYMMDD>-<git-sha7>` | Immutable, reproducible reference. Use this in CI / READMEs / smoke runs. |
+| `latest` | Mutable convenience tag. Pushed only when the current branch is `master` and the working tree is clean. |
+
+Authentication is the caller's responsibility:
+
+```bash
+gh auth token | docker login ghcr.io -u <user> --password-stdin
+```
+
+Build and push every target:
+
+```bash
+DOCKER_HOST=tcp://localhost:2375 tests/docker/publish-images.sh all
+```
+
+Single target:
+
+```bash
+DOCKER_HOST=tcp://localhost:2375 tests/docker/publish-images.sh fedora-44
+```
+
+Dry-run (prints the resolved buildx command and tags without pushing):
+
+```bash
+KREMA_DOCKER_DRY_RUN=1 tests/docker/publish-images.sh all
+```
+
+Override the `:latest` policy:
+
+```bash
+KREMA_DOCKER_PUSH_LATEST=1 tests/docker/publish-images.sh fedora-44  # always push :latest
+KREMA_DOCKER_PUSH_LATEST=0 tests/docker/publish-images.sh fedora-44  # never push :latest
+```
+
+Notes:
+
+- All targets except `opensuse-slowroll` are published as `linux/amd64,linux/arm64`. Slowroll is `linux/amd64` only because the OBS Slowroll repository is amd64-only.
+- Multi-arch builds require QEMU binfmt handlers for the non-native architecture. On Arch:
+
+  ```bash
+  sudo pacman -S qemu-user-static qemu-user-static-binfmt
+  sudo systemctl restart systemd-binfmt
+  ```
+
+- Layer timestamps are normalised via `SOURCE_DATE_EPOCH` set to the commit time of the latest input change, so identical inputs produce byte-identical layer hashes.
+- Provenance and SBOM attestations are disabled (`--provenance=false --sbom=false`) to keep manifests small.
+- The buildx builder (default name `krema-multiarch`) is auto-created with `--driver docker-container --bootstrap` on first use.
+
+OCI image labels embedded in every push:
+
+- `org.opencontainers.image.{source,url,documentation,licenses}` — project URLs
+- `org.opencontainers.image.{revision,created,version}` — git SHA, commit time, immutable tag
+- `org.opencontainers.image.base.{name,digest}` — base image lock
+- `com.bhyoo.krema.{target,family}` — per-target metadata
+
+## Pull from ghcr.io
+
+```bash
+docker pull ghcr.io/isac322/krema-gui-runtime-fedora-44:latest
+# or pin to an immutable build:
+docker pull ghcr.io/isac322/krema-gui-runtime-fedora-44:20260529-103b39e
+```
+
+Use a published image with the existing smoke runner by re-tagging it to the local naming convention:
+
+```bash
+TARGET=fedora-44
+TAG=latest   # or 20260529-103b39e
+docker pull ghcr.io/isac322/krema-gui-runtime-$TARGET:$TAG
+docker tag ghcr.io/isac322/krema-gui-runtime-$TARGET:$TAG krema/gui-runtime:$TARGET
+DOCKER_HOST=tcp://localhost:2375 tests/docker/run-smoke.sh $TARGET /path/to/osc/results/$TARGET
 ```
 
 ## Build packages with osc

--- a/tests/docker/build-images.sh
+++ b/tests/docker/build-images.sh
@@ -2,6 +2,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2026 Krema Contributors
 
+# Build runtime smoke images locally from the digest-pinned base recorded in
+# targets.tsv. Each target's base image is passed to Dockerfile.runtime as
+# `BASE_IMAGE=docker.io/<image>@<sha256:digest>` so rebuilds against the
+# same locked targets.tsv row are reproducible.
+
 set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,6 +19,10 @@ target_filter="${1:-all}"
 usage() {
     cat <<'EOF'
 Usage: tests/docker/build-images.sh [target-id|all]
+
+Builds runtime smoke images locally using the sha256 base_digest from
+targets.tsv. Run tests/docker/update-digests.sh first if any row still has
+a `pending` base_digest value.
 
 Environment:
   DOCKER_HOST                 Docker daemon endpoint (default: tcp://localhost:2375)
@@ -31,26 +40,47 @@ build_target() {
     local target_id="$1"
     local family="$2"
     local base_image="$3"
+    local base_digest="$4"
 
+    if [[ "$base_digest" != sha256:* ]]; then
+        echo "ERROR: $target_id has unresolved base_digest ('$base_digest')." >&2
+        echo "  Run tests/docker/update-digests.sh $target_id to lock it." >&2
+        exit 65
+    fi
+
+    local pinned_base="docker.io/${base_image}@${base_digest}"
     local tag="$image_prefix:$target_id"
-    local args=(build --pull -f "$script_dir/Dockerfile.runtime" -t "$tag" --build-arg "BASE_IMAGE=$base_image" --build-arg "TARGET_ID=$target_id" --build-arg "FAMILY=$family")
+    local args=(build -f "$script_dir/Dockerfile.runtime" -t "$tag"
+        --build-arg "BASE_IMAGE=$pinned_base"
+        --build-arg "TARGET_ID=$target_id"
+        --build-arg "FAMILY=$family")
     if [[ -n "$platform" ]]; then
         args+=(--platform "$platform")
     fi
     args+=("$script_dir")
 
-    echo "Building $tag from $base_image"
+    echo "Building $tag from $pinned_base"
     DOCKER_HOST="$docker_host" docker "${args[@]}"
 }
 
 matched=0
-while IFS=$'\t' read -r target_id family base_image obs_repository package_glob; do
-    [[ -z "${target_id:-}" || "${target_id:0:1}" == "#" ]] && continue
+while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+    if [[ -z "${raw_line//[[:space:]]/}" || "${raw_line:0:1}" == "#" ]]; then
+        continue
+    fi
+    IFS=$'\t' read -r target_id family base_image base_digest obs_repository package_glob <<<"$raw_line"
+    if [[ -z "${target_id:-}" || -z "${family:-}" || -z "${base_image:-}" \
+          || -z "${base_digest:-}" || -z "${obs_repository:-}" \
+          || -z "${package_glob:-}" ]]; then
+        echo "ERROR: malformed targets.tsv row (need 6 TAB-separated columns):" >&2
+        printf '  %s\n' "$raw_line" >&2
+        exit 65
+    fi
     if [[ "$target_filter" != "all" && "$target_filter" != "$target_id" ]]; then
         continue
     fi
     matched=1
-    build_target "$target_id" "$family" "$base_image"
+    build_target "$target_id" "$family" "$base_image" "$base_digest"
 done <"$targets_file"
 
 if ((matched == 0)); then

--- a/tests/docker/publish-images.sh
+++ b/tests/docker/publish-images.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Krema Contributors
+
+# Build per-distro runtime smoke images and push them to GitHub Container
+# Registry as OCI manifests. Inputs:
+#
+#   - tests/docker/targets.tsv          (digest-pinned base per target)
+#   - tests/docker/Dockerfile.runtime
+#   - tests/docker/container-smoke.sh   (copied into the image)
+#
+# Image tag scheme (per-target repo):
+#   ghcr.io/<owner>/<repo-prefix>-<target_id>:<YYYYMMDD>-<git-sha7>  ← immutable
+#   ghcr.io/<owner>/<repo-prefix>-<target_id>:latest                 ← convenience
+#
+# :latest is pushed only when the current branch is master AND the working
+# tree is clean (override with KREMA_DOCKER_PUSH_LATEST=1 or =0).
+#
+# opensuse-slowroll has amd64-only packages and is published as a single
+# linux/amd64 manifest. Every other target is linux/amd64,linux/arm64.
+#
+# Reproducibility levers:
+#   - BASE_IMAGE is pinned to docker.io/<image>@<sha256:digest> from the
+#     lockfile (refresh via tests/docker/update-digests.sh).
+#   - SOURCE_DATE_EPOCH is set to the commit timestamp of the latest input
+#     change so layer mtimes are normalised.
+#   - --provenance=false --sbom=false suppress the extra attestation
+#     manifests buildx attaches by default.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+targets_file="$script_dir/targets.tsv"
+
+docker_host="${DOCKER_HOST:-tcp://localhost:2375}"
+ghcr_owner="${KREMA_GHCR_OWNER:-isac322}"
+ghcr_repo_prefix="${KREMA_GHCR_REPO_PREFIX:-krema-gui-runtime}"
+builder="${KREMA_DOCKER_BUILDER:-krema-multiarch}"
+dry_run="${KREMA_DOCKER_DRY_RUN:-0}"
+push_latest_override="${KREMA_DOCKER_PUSH_LATEST:-}"
+target_filter="${1:-all}"
+
+usage() {
+    cat <<'EOF'
+Usage: tests/docker/publish-images.sh [target-id|all]
+
+Builds runtime smoke images with `docker buildx` from the digest-pinned
+base recorded in targets.tsv and pushes them to GHCR as OCI manifests.
+Slowroll is published linux/amd64-only; every other target is
+linux/amd64,linux/arm64.
+
+Authentication is the caller's responsibility, for example:
+  gh auth token | docker login ghcr.io -u <user> --password-stdin
+
+Environment:
+  DOCKER_HOST                Docker daemon endpoint (default: tcp://localhost:2375)
+  KREMA_GHCR_OWNER           ghcr owner (default: isac322)
+  KREMA_GHCR_REPO_PREFIX     repo prefix (default: krema-gui-runtime)
+  KREMA_DOCKER_BUILDER       buildx builder name (default: krema-multiarch).
+                             Auto-created with `--driver docker-container --bootstrap`
+                             on first run if missing.
+  KREMA_DOCKER_DRY_RUN       If 1, omit --push and only print the resolved
+                             buildx command and tags. Default: 0.
+  KREMA_DOCKER_PUSH_LATEST   Override the auto-detected :latest policy:
+                             1 → always push :latest, 0 → never push :latest.
+                             Unset → push :latest only on a clean master tree.
+
+Lockfile prerequisites:
+  - Every targets.tsv row must have a sha256: base_digest.
+    Refresh via: tests/docker/update-digests.sh [target|all]
+
+Multi-arch prerequisites:
+  - For multi-arch targets the host must have QEMU binfmt handlers for the
+    non-native architecture. Install on Arch with:
+      sudo pacman -S qemu-user-static qemu-user-static-binfmt
+      sudo systemctl restart systemd-binfmt
+EOF
+}
+
+if [[ "$target_filter" == "--help" || "$target_filter" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "ERROR: git is required" >&2
+    exit 65
+fi
+
+cd "$repo_root"
+
+git_sha="$(git rev-parse HEAD)"
+git_sha7="$(git rev-parse --short=7 HEAD)"
+date_tag="$(date -u +%Y%m%d)"
+immutable_suffix="${date_tag}-${git_sha7}"
+
+# Pin SOURCE_DATE_EPOCH to the latest commit that touched any build input.
+src_files=(
+    tests/docker/Dockerfile.runtime
+    tests/docker/container-smoke.sh
+    tests/docker/targets.tsv
+)
+src_epoch="$(git log -1 --format=%ct -- "${src_files[@]}")"
+if [[ -z "$src_epoch" ]]; then
+    src_epoch="$(git log -1 --format=%ct HEAD)"
+fi
+src_iso="$(date -u -d "@$src_epoch" +%Y-%m-%dT%H:%M:%SZ)"
+
+# Decide whether to push :latest.
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+tree_dirty="$(git status --porcelain | wc -l)"
+case "$push_latest_override" in
+    1)   push_latest=1 ;;
+    0)   push_latest=0 ;;
+    "")  if [[ "$current_branch" == "master" && "$tree_dirty" -eq 0 ]]; then
+             push_latest=1
+         else
+             push_latest=0
+         fi ;;
+    *)   echo "ERROR: KREMA_DOCKER_PUSH_LATEST must be 0 or 1 (got '$push_latest_override')" >&2
+         exit 64 ;;
+esac
+
+ensure_builder() {
+    if DOCKER_HOST="$docker_host" docker buildx inspect "$builder" >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "Creating buildx builder: $builder" >&2
+    DOCKER_HOST="$docker_host" docker buildx create \
+        --name "$builder" --driver docker-container --bootstrap >/dev/null
+}
+
+publish_target() {
+    local target_id="$1"
+    local family="$2"
+    local base_image="$3"
+    local base_digest="$4"
+
+    if [[ "$base_digest" != sha256:* ]]; then
+        echo "ERROR: $target_id has unresolved base_digest ('$base_digest')." >&2
+        echo "  Run tests/docker/update-digests.sh $target_id to lock it." >&2
+        exit 65
+    fi
+
+    local platforms="linux/amd64,linux/arm64"
+    if [[ "$target_id" == "opensuse-slowroll" ]]; then
+        platforms="linux/amd64"
+    fi
+
+    local pinned_base="docker.io/${base_image}@${base_digest}"
+    local repo="ghcr.io/${ghcr_owner}/${ghcr_repo_prefix}-${target_id}"
+    local immutable_tag="${repo}:${immutable_suffix}"
+    local latest_tag="${repo}:latest"
+
+    local args=(
+        buildx build
+        --builder "$builder"
+        --platform "$platforms"
+        --provenance=false
+        --sbom=false
+        --build-arg "BASE_IMAGE=$pinned_base"
+        --build-arg "TARGET_ID=$target_id"
+        --build-arg "FAMILY=$family"
+        --build-arg "SOURCE_DATE_EPOCH=$src_epoch"
+        --label "org.opencontainers.image.revision=$git_sha"
+        --label "org.opencontainers.image.created=$src_iso"
+        --label "org.opencontainers.image.version=$immutable_suffix"
+        --label "org.opencontainers.image.source=https://github.com/isac322/krema"
+        --label "org.opencontainers.image.url=https://github.com/isac322/krema"
+        --label "org.opencontainers.image.documentation=https://github.com/isac322/krema/blob/master/tests/docker/README.md"
+        --label "org.opencontainers.image.licenses=GPL-3.0-or-later"
+        --label "org.opencontainers.image.base.name=docker.io/${base_image}"
+        --label "org.opencontainers.image.base.digest=$base_digest"
+        --label "com.bhyoo.krema.target=$target_id"
+        --label "com.bhyoo.krema.family=$family"
+        --tag "$immutable_tag"
+    )
+    if ((push_latest == 1)); then
+        args+=(--tag "$latest_tag")
+    fi
+
+    if ((dry_run == 1)); then
+        echo "[DRY RUN] $immutable_tag  (platforms: $platforms)"
+        if ((push_latest == 1)); then
+            echo "[DRY RUN] $latest_tag  (also pushed)"
+        else
+            echo "[DRY RUN] (:latest not pushed; branch=$current_branch, dirty=$tree_dirty, override=${push_latest_override:-auto})"
+        fi
+        echo "[DRY RUN] command: docker ${args[*]} --file $script_dir/Dockerfile.runtime $script_dir"
+        return 0
+    fi
+
+    args+=(--push --file "$script_dir/Dockerfile.runtime" "$script_dir")
+
+    echo "Publishing $immutable_tag (platforms: $platforms)"
+    if ((push_latest == 1)); then
+        echo "             + $latest_tag"
+    fi
+    DOCKER_HOST="$docker_host" docker "${args[@]}"
+}
+
+if ((dry_run == 0)); then
+    ensure_builder
+fi
+
+matched=0
+while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+    if [[ -z "${raw_line//[[:space:]]/}" || "${raw_line:0:1}" == "#" ]]; then
+        continue
+    fi
+    IFS=$'\t' read -r target_id family base_image base_digest obs_repository package_glob <<<"$raw_line"
+    if [[ -z "${target_id:-}" || -z "${family:-}" || -z "${base_image:-}" \
+          || -z "${base_digest:-}" || -z "${obs_repository:-}" \
+          || -z "${package_glob:-}" ]]; then
+        echo "ERROR: malformed targets.tsv row (need 6 TAB-separated columns):" >&2
+        printf '  %s\n' "$raw_line" >&2
+        exit 65
+    fi
+    if [[ "$target_filter" != "all" && "$target_filter" != "$target_id" ]]; then
+        continue
+    fi
+    matched=1
+    publish_target "$target_id" "$family" "$base_image" "$base_digest"
+done <"$targets_file"
+
+if ((matched == 0)); then
+    echo "No target matched: $target_filter" >&2
+    exit 64
+fi

--- a/tests/docker/targets.tsv
+++ b/tests/docker/targets.tsv
@@ -1,18 +1,25 @@
 # Docker GUI runtime targets derived from the supported OBS/package matrix.
 #
 # Columns:
-# target_id<TAB>family<TAB>base_image<TAB>obs_repository<TAB>package_glob
+# target_id<TAB>family<TAB>base_image<TAB>base_digest<TAB>obs_repository<TAB>package_glob
+#
+# base_digest is the sha256 multi-arch manifest list digest of base_image,
+# locked via tests/docker/update-digests.sh. The literal value `pending` is
+# used for rows that have not been locked yet. Single-platform targets (for
+# example opensuse-slowroll, which has amd64-only packages) still record the
+# multi-arch manifest digest; the platform constraint is applied at publish
+# time, not in the lockfile.
 #
 # The image contains the distro runtime and install tools only. Krema packages
 # are built externally (for example with osc) and mounted at smoke-test time.
-opensuse-tumbleweed	suse	opensuse/tumbleweed:latest	openSUSE_Tumbleweed	*.rpm
-opensuse-slowroll	suse	opensuse/tumbleweed:latest	openSUSE_Slowroll	*.rpm
-opensuse-leap-16.0	suse	opensuse/leap:16.0	openSUSE_Leap_16.0	*.rpm
-fedora-42	fedora	fedora:42	Fedora_42	*.rpm
-fedora-43	fedora	fedora:43	Fedora_43	*.rpm
-fedora-44	fedora	fedora:44	Fedora_44	*.rpm
-fedora-rawhide	fedora	fedora:rawhide	Fedora_Rawhide	*.rpm
-debian-13	debian	debian:13-slim	Debian_13	*.deb
-ubuntu-25.04	debian	ubuntu:25.04	xUbuntu_25.04	*.deb
-ubuntu-25.10	debian	ubuntu:25.10	xUbuntu_25.10	*.deb
-ubuntu-26.04	debian	ubuntu:26.04	xUbuntu_26.04	*.deb
+opensuse-tumbleweed	suse	opensuse/tumbleweed:latest	sha256:0b5175be65a62f660359d97eda0f7e27187d16307b3dd55b18aeb41b97edcb9f	openSUSE_Tumbleweed	*.rpm
+opensuse-slowroll	suse	opensuse/tumbleweed:latest	sha256:0b5175be65a62f660359d97eda0f7e27187d16307b3dd55b18aeb41b97edcb9f	openSUSE_Slowroll	*.rpm
+opensuse-leap-16.0	suse	opensuse/leap:16.0	sha256:859560554b625c225fa767b76d61253d529b95d082c2d68579ad69168d5e3da7	openSUSE_Leap_16.0	*.rpm
+fedora-42	fedora	fedora:42	sha256:99e203b80b1c3d8f7e161ec10a68fd02b081ef83a3963553e513c82846b97814	Fedora_42	*.rpm
+fedora-43	fedora	fedora:43	sha256:762d73ba1c455232b0272c5d445a34f36c4b9f421cbc05ce8102552325b6a222	Fedora_43	*.rpm
+fedora-44	fedora	fedora:44	sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898	Fedora_44	*.rpm
+fedora-rawhide	fedora	fedora:rawhide	sha256:0c1f63ed8fb818fad16cf6ae091598c410a21d2e1a9adf183beb93189299bfba	Fedora_Rawhide	*.rpm
+debian-13	debian	debian:13-slim	sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8	Debian_13	*.deb
+ubuntu-25.04	debian	ubuntu:25.04	sha256:27771fb7b40a58237c98e8d3e6b9ecdd9289cec69a857fccfb85ff36294dac20	xUbuntu_25.04	*.deb
+ubuntu-25.10	debian	ubuntu:25.10	sha256:4a9232cc47bf99defcc8860ef6222c99773330367fcecbf21ba2edb0b810a31e	xUbuntu_25.10	*.deb
+ubuntu-26.04	debian	ubuntu:26.04	sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64	xUbuntu_26.04	*.deb

--- a/tests/docker/update-digests.sh
+++ b/tests/docker/update-digests.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Krema Contributors
+
+# Refresh the base_digest column of targets.tsv by resolving the current
+# sha256 manifest digest of each base_image via
+# `docker buildx imagetools inspect`.
+#
+# Targets file format (TAB-separated):
+#   target_id<TAB>family<TAB>base_image<TAB>base_digest<TAB>obs_repository<TAB>package_glob
+#
+# The base_digest column is the multi-arch manifest list digest even when
+# the runtime image is later built single-platform (for example Slowroll
+# is amd64-only). The single-platform constraint is enforced by the
+# publish workflow, not by the lockfile, so multiple target rows can share
+# the same base_image and therefore the same base_digest.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+targets_file="$script_dir/targets.tsv"
+docker_host="${DOCKER_HOST:-tcp://localhost:2375}"
+
+usage() {
+    cat <<'EOF'
+Usage: tests/docker/update-digests.sh [target-id|all]
+
+Resolves the current sha256 manifest digest of each target's base_image
+via `docker buildx imagetools inspect` and rewrites targets.tsv in place.
+
+Environment:
+  DOCKER_HOST   Docker daemon endpoint (default: tcp://localhost:2375)
+
+Notes:
+  - targets.tsv must be in 6-column format
+    (target_id, family, base_image, base_digest, obs_repository, package_glob).
+  - Use the literal value `pending` (or any non-sha256: string) in the
+    base_digest column for rows that have not been locked yet.
+  - Comments (#) and blank lines pass through unchanged. Data row order is
+    preserved.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+target_filter="${1:-all}"
+
+if [[ ! -f "$targets_file" ]]; then
+    echo "targets file not found: $targets_file" >&2
+    exit 66
+fi
+
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+matched=0
+while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+    if [[ -z "${raw_line//[[:space:]]/}" || "${raw_line:0:1}" == "#" ]]; then
+        printf '%s\n' "$raw_line" >>"$tmp_file"
+        continue
+    fi
+
+    IFS=$'\t' read -r target_id family base_image base_digest obs_repository package_glob <<<"$raw_line"
+
+    if [[ -z "${target_id:-}" || -z "${family:-}" || -z "${base_image:-}" \
+          || -z "${obs_repository:-}" || -z "${package_glob:-}" ]]; then
+        echo "ERROR: malformed row (need 6 TAB-separated columns):" >&2
+        printf '  %s\n' "$raw_line" >&2
+        exit 65
+    fi
+
+    if [[ "$target_filter" != "all" && "$target_filter" != "$target_id" ]]; then
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$target_id" "$family" "$base_image" "$base_digest" \
+            "$obs_repository" "$package_glob" >>"$tmp_file"
+        continue
+    fi
+
+    matched=1
+    echo "Resolving $target_id (base $base_image)..." >&2
+
+    if ! resolved="$(
+            DOCKER_HOST="$docker_host" docker buildx imagetools inspect \
+                "docker.io/$base_image" --format '{{.Manifest.Digest}}' 2>&1
+        )"; then
+        echo "ERROR: failed to inspect docker.io/$base_image" >&2
+        printf '  %s\n' "$resolved" >&2
+        exit 67
+    fi
+
+    if [[ "$resolved" != sha256:* ]]; then
+        echo "ERROR: unexpected digest format for $base_image: '$resolved'" >&2
+        exit 67
+    fi
+
+    printf '  %s -> %s\n' "$base_digest" "$resolved" >&2
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$target_id" "$family" "$base_image" "$resolved" \
+        "$obs_repository" "$package_glob" >>"$tmp_file"
+done <"$targets_file"
+
+if ((matched == 0)); then
+    echo "No target matched: $target_filter" >&2
+    exit 64
+fi
+
+mv "$tmp_file" "$targets_file"
+trap - EXIT
+echo "Updated $targets_file" >&2


### PR DESCRIPTION
## Summary

Two reinforcements on top of the Docker GUI smoke infrastructure introduced in #7:

1. **Base image digest pinning** — adds a `base_digest` column to `tests/docker/targets.tsv` and locks all 11 base images by `sha256:...` for byte-for-byte reproducible builds.
2. **ghcr publish pipeline** — multi-arch buildx script that pushes 11 runtime images to `ghcr.io/<owner>/krema-gui-runtime-<target>`.

## Changes

### Phase A — digest lock (3c96ce1)
- `tests/docker/targets.tsv`: 5 → 6 columns (added `base_digest`). All 11 target base images locked to their current sha256.
- `tests/docker/update-digests.sh` (new): refreshes TSV digests via `docker buildx imagetools inspect`.
- `tests/docker/build-images.sh`: parses 6 columns, passes `--build-arg BASE_IMAGE=docker.io/<image>@<sha256>`. Removed `--pull` (digest pin makes it redundant).

### Phase B — ghcr publish (6114fd0)
- `tests/docker/publish-images.sh` (new):
  - Per-target repo: `ghcr.io/<owner>/<prefix>-<target>` (default prefix `krema-gui-runtime`).
  - Immutable tag `YYYYMMDD-<sha7>` + mutable `latest` (auto on master + clean tree, overridable via `KREMA_DOCKER_PUSH_LATEST=0/1`).
  - Multi-arch: `linux/amd64,linux/arm64` (Slowroll forced to amd64 only).
  - `--provenance=false --sbom=false`, dedicated buildx builder `krema-multiarch`.
  - `SOURCE_DATE_EPOCH`: commit timestamp of the latest change touching `Dockerfile.runtime` / `targets.tsv`.
  - OCI labels: `org.opencontainers.image.{revision,created,version,source,url,documentation,licenses,base.name,base.digest}` + `com.bhyoo.krema.{target,family}`.
  - `KREMA_DOCKER_DRY_RUN=1` prints the buildx command without executing.
- `justfile`: added `docker-runtime-update-digests`, `docker-runtime-publish` recipes.
- `tests/docker/README.md`: ghcr pull usage + reproducibility mechanism + Slowroll single-platform note.

## Verification

- `bash -n` on all 5 docker scripts: clean.
- Phase A: 10/11 targets rebuilt locally (arm64 native) from digest-pinned bases. Slowroll fails for a separate reason (see blocker below).
- Phase B: all 11 targets pass dry-run. Emitted buildx command carries the right platforms, labels, build-args, and `SOURCE_DATE_EPOCH`.

## Slowroll blocker

Host is **Apple Silicon Asahi Linux (arm64, kernel 6.19, PAGESIZE=16384)**.

amd64 base images fail at dynamic library mmap due to segment alignment mismatch (16K host page size vs 4K amd64 ELF segment alignment).
qemu-user 11.0.0 + binfmt also fail inside containers because host arm64 ld-linux and libs aren't reachable in the chroot.
Distro-agnostic — reproduced on Ubuntu, Tumbleweed, and Slowroll.

→ amd64 builds (including Slowroll) must run on a native amd64 machine (`DOCKER_HOST=tcp://amd64host:2375 tests/docker/publish-images.sh all`) or on a GH Actions amd64 runner.

This PR is opened so the actual publish can be driven from such a machine.

## Out of scope

- Actually pushing images to ghcr (will be done from an amd64 host).
- CI workflow automation.