### PR TITLE
perf(tests): parallelise per-distro runtime image builds

### DIFF
--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -57,6 +57,25 @@ KREMA_DOCKER_PLATFORM=linux/arm64 DOCKER_HOST=tcp://localhost:2375 tests/docker/
 
 If any `targets.tsv` row still has a `pending` `base_digest` value the build aborts with an instruction to run `update-digests.sh` first.
 
+## Parallel builds
+
+Both `build-images.sh` and `publish-images.sh` build up to `KREMA_DOCKER_PARALLEL` targets concurrently (default `4`). When more than one target is selected, each target's output is redirected to `KREMA_DOCKER_LOG_DIR/<target>.log` (default `${TMPDIR:-/tmp}/krema-{build,publish}-images/<target>.log`) and a pass/fail summary is printed at the end. The script exits non-zero if any target fails.
+
+Single-target invocations and `KREMA_DOCKER_PARALLEL=1` keep the original streaming-to-terminal behaviour. Dry-run (`KREMA_DOCKER_DRY_RUN=1`) also stays serial so the resolved buildx commands print in target order.
+
+```bash
+# Default: 4-wide parallel build of every target
+DOCKER_HOST=tcp://localhost:2375 tests/docker/build-images.sh all
+
+# 8-wide on a beefier machine
+KREMA_DOCKER_PARALLEL=8 DOCKER_HOST=tcp://localhost:2375 tests/docker/publish-images.sh all
+
+# Old serial behaviour
+KREMA_DOCKER_PARALLEL=1 DOCKER_HOST=tcp://localhost:2375 tests/docker/build-images.sh all
+```
+
+Parallel mode requires bash 5.1+ (uses `wait -n -p`). The scripts refuse to run with `KREMA_DOCKER_PARALLEL>1` on older bash and tell the caller to set `KREMA_DOCKER_PARALLEL=1`.
+
 ## Publish to ghcr.io
 
 `tests/docker/publish-images.sh` builds each image with `docker buildx` from the locked base digest and pushes a multi-arch OCI manifest to `ghcr.io/<owner>/<repo-prefix>-<target_id>` (default: `ghcr.io/isac322/krema-gui-runtime-<target_id>`).

--- a/tests/docker/build-images.sh
+++ b/tests/docker/build-images.sh
@@ -6,6 +6,10 @@
 # targets.tsv. Each target's base image is passed to Dockerfile.runtime as
 # `BASE_IMAGE=docker.io/<image>@<sha256:digest>` so rebuilds against the
 # same locked targets.tsv row are reproducible.
+#
+# When multiple targets are selected, builds run in parallel (default 4
+# concurrent jobs). Each target's docker build output is streamed to a
+# per-target log file and a pass/fail summary is printed at the end.
 
 set -euo pipefail
 
@@ -14,6 +18,8 @@ targets_file="$script_dir/targets.tsv"
 image_prefix="${KREMA_DOCKER_IMAGE_PREFIX:-krema/gui-runtime}"
 docker_host="${DOCKER_HOST:-tcp://localhost:2375}"
 platform="${KREMA_DOCKER_PLATFORM:-}"
+parallel="${KREMA_DOCKER_PARALLEL:-4}"
+log_dir="${KREMA_DOCKER_LOG_DIR:-${TMPDIR:-/tmp}/krema-build-images}"
 target_filter="${1:-all}"
 
 usage() {
@@ -24,16 +30,29 @@ Builds runtime smoke images locally using the sha256 base_digest from
 targets.tsv. Run tests/docker/update-digests.sh first if any row still has
 a `pending` base_digest value.
 
+Multiple targets build in parallel by default (4 concurrent jobs). Each
+target's output is captured to $KREMA_DOCKER_LOG_DIR/<target>.log.
+
 Environment:
   DOCKER_HOST                 Docker daemon endpoint (default: tcp://localhost:2375)
   KREMA_DOCKER_IMAGE_PREFIX   Image prefix (default: krema/gui-runtime)
   KREMA_DOCKER_PLATFORM       Optional Docker platform, for example linux/amd64 or linux/arm64
+  KREMA_DOCKER_PARALLEL       Max concurrent target builds (default: 4). Set to 1
+                              to stream output sequentially like the old behaviour.
+                              Values >1 require bash 5.1+.
+  KREMA_DOCKER_LOG_DIR        Per-target log directory when parallel>1
+                              (default: ${TMPDIR:-/tmp}/krema-build-images)
 EOF
 }
 
 if [[ "$target_filter" == "--help" || "$target_filter" == "-h" ]]; then
     usage
     exit 0
+fi
+
+if ! [[ "$parallel" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: KREMA_DOCKER_PARALLEL must be a positive integer (got '$parallel')" >&2
+    exit 64
 fi
 
 build_target() {
@@ -45,7 +64,7 @@ build_target() {
     if [[ "$base_digest" != sha256:* ]]; then
         echo "ERROR: $target_id has unresolved base_digest ('$base_digest')." >&2
         echo "  Run tests/docker/update-digests.sh $target_id to lock it." >&2
-        exit 65
+        return 65
     fi
 
     local pinned_base="docker.io/${base_image}@${base_digest}"
@@ -63,7 +82,7 @@ build_target() {
     DOCKER_HOST="$docker_host" docker "${args[@]}"
 }
 
-matched=0
+selected_lines=()
 while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
     if [[ -z "${raw_line//[[:space:]]/}" || "${raw_line:0:1}" == "#" ]]; then
         continue
@@ -79,11 +98,100 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
     if [[ "$target_filter" != "all" && "$target_filter" != "$target_id" ]]; then
         continue
     fi
-    matched=1
-    build_target "$target_id" "$family" "$base_image" "$base_digest"
+    selected_lines+=("$target_id"$'\t'"$family"$'\t'"$base_image"$'\t'"$base_digest")
 done <"$targets_file"
 
-if ((matched == 0)); then
+if ((${#selected_lines[@]} == 0)); then
     echo "No target matched: $target_filter" >&2
     exit 64
+fi
+
+ok_list=()
+fail_list=()
+
+# Serial / streaming mode: single target OR parallel=1.
+if ((${#selected_lines[@]} == 1 || parallel == 1)); then
+    for tuple in "${selected_lines[@]}"; do
+        IFS=$'\t' read -r t_id t_family t_base t_digest <<<"$tuple"
+        if build_target "$t_id" "$t_family" "$t_base" "$t_digest"; then
+            ok_list+=("$t_id")
+        else
+            rc=$?
+            echo "FAIL $t_id (exit $rc)" >&2
+            fail_list+=("$t_id")
+        fi
+    done
+else
+    if ((BASH_VERSINFO[0] < 5)) || ((BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 1)); then
+        echo "ERROR: KREMA_DOCKER_PARALLEL=$parallel requires bash 5.1+ (have ${BASH_VERSION})." >&2
+        echo "  Set KREMA_DOCKER_PARALLEL=1 or upgrade bash." >&2
+        exit 65
+    fi
+
+    mkdir -p "$log_dir"
+    echo "Parallel build: up to $parallel concurrent, ${#selected_lines[@]} targets"
+    echo "Logs: $log_dir/<target>.log"
+    echo
+
+    declare -A pid_to_target
+    declare -A pid_to_log
+    queue=("${selected_lines[@]}")
+    running=0
+
+    start_next() {
+        ((${#queue[@]} == 0)) && return 1
+        local tuple="${queue[0]}"
+        queue=("${queue[@]:1}")
+        local t_id t_family t_base t_digest
+        IFS=$'\t' read -r t_id t_family t_base t_digest <<<"$tuple"
+        local log_file="$log_dir/$t_id.log"
+        echo "[start] $t_id  →  $log_file"
+        (build_target "$t_id" "$t_family" "$t_base" "$t_digest") \
+            >"$log_file" 2>&1 &
+        local p=$!
+        pid_to_target[$p]="$t_id"
+        pid_to_log[$p]="$log_file"
+        running=$((running + 1))
+        return 0
+    }
+
+    for ((i = 0; i < parallel; i++)); do
+        start_next || break
+    done
+
+    finished_pid=""
+    while ((running > 0)); do
+        finished_pid=""
+        rc=0
+        wait -n -p finished_pid || rc=$?
+        running=$((running - 1))
+        if [[ -z "$finished_pid" ]]; then
+            echo "[warn] wait -n returned without a pid" >&2
+            continue
+        fi
+        tid="${pid_to_target[$finished_pid]:-unknown}"
+        logf="${pid_to_log[$finished_pid]:-}"
+        unset 'pid_to_target[$finished_pid]'
+        unset 'pid_to_log[$finished_pid]'
+        if ((rc == 0)); then
+            echo "[ok]    $tid"
+            ok_list+=("$tid")
+        else
+            echo "[fail]  $tid (exit $rc, see $logf)"
+            fail_list+=("$tid")
+        fi
+        start_next || true
+    done
+fi
+
+echo
+echo "=== Build summary ==="
+if ((${#ok_list[@]} > 0)); then
+    echo "Pass (${#ok_list[@]}): ${ok_list[*]}"
+else
+    echo "Pass (0): -"
+fi
+if ((${#fail_list[@]} > 0)); then
+    echo "Fail (${#fail_list[@]}): ${fail_list[*]}" >&2
+    exit 1
 fi

--- a/tests/docker/publish-images.sh
+++ b/tests/docker/publish-images.sh
@@ -19,6 +19,10 @@
 # opensuse-slowroll has amd64-only packages and is published as a single
 # linux/amd64 manifest. Every other target is linux/amd64,linux/arm64.
 #
+# When multiple targets are selected, builds run in parallel (default 4
+# concurrent jobs). Each target's buildx output streams to a per-target log
+# file and a pass/fail summary is printed at the end.
+#
 # Reproducibility levers:
 #   - BASE_IMAGE is pinned to docker.io/<image>@<sha256:digest> from the
 #     lockfile (refresh via tests/docker/update-digests.sh).
@@ -39,6 +43,8 @@ ghcr_repo_prefix="${KREMA_GHCR_REPO_PREFIX:-krema-gui-runtime}"
 builder="${KREMA_DOCKER_BUILDER:-krema-multiarch}"
 dry_run="${KREMA_DOCKER_DRY_RUN:-0}"
 push_latest_override="${KREMA_DOCKER_PUSH_LATEST:-}"
+parallel="${KREMA_DOCKER_PARALLEL:-4}"
+log_dir="${KREMA_DOCKER_LOG_DIR:-${TMPDIR:-/tmp}/krema-publish-images}"
 target_filter="${1:-all}"
 
 usage() {
@@ -49,6 +55,9 @@ Builds runtime smoke images with `docker buildx` from the digest-pinned
 base recorded in targets.tsv and pushes them to GHCR as OCI manifests.
 Slowroll is published linux/amd64-only; every other target is
 linux/amd64,linux/arm64.
+
+Multiple targets build in parallel by default (4 concurrent jobs). Each
+target's output is captured to $KREMA_DOCKER_LOG_DIR/<target>.log.
 
 Authentication is the caller's responsibility, for example:
   gh auth token | docker login ghcr.io -u <user> --password-stdin
@@ -65,6 +74,11 @@ Environment:
   KREMA_DOCKER_PUSH_LATEST   Override the auto-detected :latest policy:
                              1 → always push :latest, 0 → never push :latest.
                              Unset → push :latest only on a clean master tree.
+  KREMA_DOCKER_PARALLEL      Max concurrent target builds (default: 4). Set to 1
+                             to stream output sequentially like the old behaviour.
+                             Values >1 require bash 5.1+.
+  KREMA_DOCKER_LOG_DIR       Per-target log directory when parallel>1
+                             (default: ${TMPDIR:-/tmp}/krema-publish-images)
 
 Lockfile prerequisites:
   - Every targets.tsv row must have a sha256: base_digest.
@@ -86,6 +100,11 @@ fi
 if ! command -v git >/dev/null 2>&1; then
     echo "ERROR: git is required" >&2
     exit 65
+fi
+
+if ! [[ "$parallel" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: KREMA_DOCKER_PARALLEL must be a positive integer (got '$parallel')" >&2
+    exit 64
 fi
 
 cd "$repo_root"
@@ -140,7 +159,7 @@ publish_target() {
     if [[ "$base_digest" != sha256:* ]]; then
         echo "ERROR: $target_id has unresolved base_digest ('$base_digest')." >&2
         echo "  Run tests/docker/update-digests.sh $target_id to lock it." >&2
-        exit 65
+        return 65
     fi
 
     local platforms="linux/amd64,linux/arm64"
@@ -200,11 +219,7 @@ publish_target() {
     DOCKER_HOST="$docker_host" docker "${args[@]}"
 }
 
-if ((dry_run == 0)); then
-    ensure_builder
-fi
-
-matched=0
+selected_lines=()
 while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
     if [[ -z "${raw_line//[[:space:]]/}" || "${raw_line:0:1}" == "#" ]]; then
         continue
@@ -220,11 +235,104 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
     if [[ "$target_filter" != "all" && "$target_filter" != "$target_id" ]]; then
         continue
     fi
-    matched=1
-    publish_target "$target_id" "$family" "$base_image" "$base_digest"
+    selected_lines+=("$target_id"$'\t'"$family"$'\t'"$base_image"$'\t'"$base_digest")
 done <"$targets_file"
 
-if ((matched == 0)); then
+if ((${#selected_lines[@]} == 0)); then
     echo "No target matched: $target_filter" >&2
     exit 64
+fi
+
+if ((dry_run == 0)); then
+    ensure_builder
+fi
+
+ok_list=()
+fail_list=()
+
+# Serial / streaming mode: single target OR parallel=1 OR dry-run.
+if ((${#selected_lines[@]} == 1 || parallel == 1 || dry_run == 1)); then
+    for tuple in "${selected_lines[@]}"; do
+        IFS=$'\t' read -r t_id t_family t_base t_digest <<<"$tuple"
+        if publish_target "$t_id" "$t_family" "$t_base" "$t_digest"; then
+            ok_list+=("$t_id")
+        else
+            rc=$?
+            echo "FAIL $t_id (exit $rc)" >&2
+            fail_list+=("$t_id")
+        fi
+    done
+else
+    if ((BASH_VERSINFO[0] < 5)) || ((BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 1)); then
+        echo "ERROR: KREMA_DOCKER_PARALLEL=$parallel requires bash 5.1+ (have ${BASH_VERSION})." >&2
+        echo "  Set KREMA_DOCKER_PARALLEL=1 or upgrade bash." >&2
+        exit 65
+    fi
+
+    mkdir -p "$log_dir"
+    echo "Parallel publish: up to $parallel concurrent, ${#selected_lines[@]} targets"
+    echo "Logs: $log_dir/<target>.log"
+    echo
+
+    declare -A pid_to_target
+    declare -A pid_to_log
+    queue=("${selected_lines[@]}")
+    running=0
+
+    start_next() {
+        ((${#queue[@]} == 0)) && return 1
+        local tuple="${queue[0]}"
+        queue=("${queue[@]:1}")
+        local t_id t_family t_base t_digest
+        IFS=$'\t' read -r t_id t_family t_base t_digest <<<"$tuple"
+        local log_file="$log_dir/$t_id.log"
+        echo "[start] $t_id  →  $log_file"
+        (publish_target "$t_id" "$t_family" "$t_base" "$t_digest") \
+            >"$log_file" 2>&1 &
+        local p=$!
+        pid_to_target[$p]="$t_id"
+        pid_to_log[$p]="$log_file"
+        running=$((running + 1))
+        return 0
+    }
+
+    for ((i = 0; i < parallel; i++)); do
+        start_next || break
+    done
+
+    finished_pid=""
+    while ((running > 0)); do
+        finished_pid=""
+        rc=0
+        wait -n -p finished_pid || rc=$?
+        running=$((running - 1))
+        if [[ -z "$finished_pid" ]]; then
+            echo "[warn] wait -n returned without a pid" >&2
+            continue
+        fi
+        tid="${pid_to_target[$finished_pid]:-unknown}"
+        logf="${pid_to_log[$finished_pid]:-}"
+        unset 'pid_to_target[$finished_pid]'
+        unset 'pid_to_log[$finished_pid]'
+        if ((rc == 0)); then
+            echo "[ok]    $tid"
+            ok_list+=("$tid")
+        else
+            echo "[fail]  $tid (exit $rc, see $logf)"
+            fail_list+=("$tid")
+        fi
+        start_next || true
+    done
+fi
+
+echo
+echo "=== Publish summary ==="
+if ((${#ok_list[@]} > 0)); then
+    echo "Pass (${#ok_list[@]}): ${ok_list[*]}"
+else
+    echo "Pass (0): -"
+fi
+if ((${#fail_list[@]} > 0)); then
+    echo "Fail (${#fail_list[@]}): ${fail_list[*]}" >&2
+    exit 1
 fi


### PR DESCRIPTION
## Summary

`tests/docker/build-images.sh` and `tests/docker/publish-images.sh` dispatched targets serially, so a full 11-distro buildx run took as long as the sum of every target. Both scripts now build up to `KREMA_DOCKER_PARALLEL` targets concurrently (default `4`).

## Changes

### Both scripts

- New env vars:
  - `KREMA_DOCKER_PARALLEL` — max concurrent target builds (default `4`, set to `1` for the old streaming behaviour).
  - `KREMA_DOCKER_LOG_DIR` — per-target log directory (default `${TMPDIR:-/tmp}/krema-{build,publish}-images`).
- Parallel mode:
  - Each target's `docker` / `docker buildx` output is captured to `<log_dir>/<target>.log`.
  - Live status lines: `[start] <target> → <log>`, `[ok] <target>`, `[fail] <target> (exit N, see <log>)`.
  - Pass/fail summary printed at the end.
  - Script exits non-zero if any target fails; **no fail-fast** — the queue keeps draining so one bad distro doesn't kill the whole run.
- Serial fallback for single-target invocations, `KREMA_DOCKER_PARALLEL=1`, and `KREMA_DOCKER_DRY_RUN=1` (so dry-run output stays ordered and readable).
- Parallel mode uses `wait -n -p` (bash 5.1+). Older bash is rejected with an actionable error.

### tests/docker/README.md

- New "Parallel builds" section documenting the env vars and bash 5.1+ requirement.

## Verification

- `bash -n` on both scripts: clean.
- `KREMA_DOCKER_DRY_RUN=1 tests/docker/publish-images.sh all`: still enumerates all 11 targets in order with correct platforms (Slowroll amd64-only, others multi-arch) and prints the pass summary.
- Parallel logic exercised against a fake `docker` that sleeps random 1–3 s and force-fails `ubuntu-25.10`:
  - With `KREMA_DOCKER_PARALLEL=3`, all 11 targets dispatched 3-wide, queue refilled correctly, failing target reported with exit code and log path, summary showed `Pass (10)` / `Fail (1): ubuntu-25.10`, script exited `1`.
  - Confirmed `set -e` does not abort the dispatch loop on a failed background job (`wait -n -p finished_pid || rc=$?`).

## Out of scope

- No change to image content, base digests, OCI labels, tag scheme, `:latest` policy, `SOURCE_DATE_EPOCH`, or buildx builder setup.
- `update-digests.sh` still serial — `imagetools inspect` is cheap and ordered output keeps the lockfile diff reviewable.