### PR TITLE
feat(wayland): allow pinning dock and preview to an output via KREMA_SCREEN

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(krema_lib STATIC
 
     utils/zoomcalculator.h
     utils/surfacegeometry.h
+    utils/screenpin.h
     utils/inputregion.h
     utils/inputregion.cpp
 

--- a/src/platform/waylanddockplatform.cpp
+++ b/src/platform/waylanddockplatform.cpp
@@ -7,6 +7,8 @@
 
 #include <QLoggingCategory>
 
+#include "utils/screenpin.h"
+
 Q_LOGGING_CATEGORY(lcWayland, "krema.platform.wayland")
 
 namespace krema
@@ -23,6 +25,8 @@ void WaylandDockPlatform::setupWindow(QWindow *window)
         qCCritical(lcWayland) << "LayerShellQt::Window::get() returned null!";
         return;
     }
+
+    applyScreenPinFromEnv(window, m_layerWindow);
 
     m_layerWindow->setLayer(LayerShellQt::Window::LayerTop);
     m_layerWindow->setScope(QStringLiteral("krema-dock"));

--- a/src/shell/previewcontroller.cpp
+++ b/src/shell/previewcontroller.cpp
@@ -158,7 +158,13 @@ void PreviewController::showPreview(int index, qreal itemGlobalPos, qreal itemEx
 
     const bool indexChanged = (m_parentIndex != index);
     m_parentIndex = index;
-    m_itemGlobalPos = itemGlobalPos;
+    // itemGlobalPos comes from QML mapToGlobal(); on outputs whose origin is
+    // not (0,0) it includes the dock window's position on the virtual desktop.
+    // recalcContentPosition() works in surface-local coordinates (clamped to
+    // the preview surface size), so undo the window offset here.
+    const auto dockEdge = m_dockView->platform()->edge();
+    const bool dockVertical = (dockEdge == DockPlatform::Edge::Left || dockEdge == DockPlatform::Edge::Right);
+    m_itemGlobalPos = itemGlobalPos - (dockVertical ? m_dockView->y() : m_dockView->x());
     m_itemExtent = itemExtent;
 
     recalcContentPosition();

--- a/src/shell/previewcontroller.cpp
+++ b/src/shell/previewcontroller.cpp
@@ -20,6 +20,8 @@
 #include <QQuickView>
 #include <QScreen>
 
+#include "utils/screenpin.h"
+
 Q_LOGGING_CATEGORY(lcPreview, "krema.shell.preview")
 
 namespace krema
@@ -53,6 +55,9 @@ void PreviewController::initialize()
     // Layer-shell configuration: overlay above the dock
     auto *layerWindow = LayerShellQt::Window::get(m_previewView);
     if (layerWindow) {
+        // Keep the preview popup on the same output as the dock
+        applyScreenPinFromEnv(m_previewView, layerWindow);
+
         layerWindow->setLayer(LayerShellQt::Window::LayerOverlay);
         layerWindow->setScope(QStringLiteral("krema-preview"));
         layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityNone);

--- a/src/utils/screenpin.h
+++ b/src/utils/screenpin.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Krema Contributors
+
+#pragma once
+
+#include <LayerShellQt/Window>
+
+#include <QGuiApplication>
+#include <QScreen>
+#include <QString>
+#include <QWindow>
+
+namespace krema
+{
+
+/// Pin a layer-shell window to the output named by the KREMA_SCREEN environment
+/// variable (e.g. KREMA_SCREEN=DP-1). No-op when the variable is unset or no
+/// output matches.
+///
+/// Escape hatch until per-screen configuration lands: without it the dock lands
+/// on Qt's primaryScreen(), which on Wayland is merely the first announced
+/// wl_output — on multi-monitor setups this is often not the screen the user
+/// considers primary (the compositor's primary output is not exposed to Qt).
+///
+/// Both the QWindow screen and the LayerShellQt screen must be set, and
+/// wantsToBeOnActiveScreen disabled — otherwise the compositor is free to pick
+/// another output for the surface.
+inline void applyScreenPinFromEnv(QWindow *window, LayerShellQt::Window *layerWindow)
+{
+    if (!window || !layerWindow) {
+        return;
+    }
+    const QString wantedScreen = qEnvironmentVariable("KREMA_SCREEN");
+    if (wantedScreen.isEmpty()) {
+        return;
+    }
+    const auto screens = QGuiApplication::screens();
+    for (QScreen *screen : screens) {
+        if (screen->name() == wantedScreen) {
+            window->setScreen(screen);
+            layerWindow->setWantsToBeOnActiveScreen(false);
+            layerWindow->setScreen(screen);
+            return;
+        }
+    }
+}
+
+}


### PR DESCRIPTION
## Problem

On a multi-monitor Plasma 6 Wayland setup, the dock always appears on Qt's `primaryScreen()` — which is merely the **first announced `wl_output`**, not the screen the user marked as primary in KDE (the compositor's primary output is not exposed to Qt). On my 3-monitor setup (all DisplayPort), the dock and the pre-shown preview surface both land on the *leftmost* monitor instead of the primary center one, with no way to move them.

## Change

- New header-only helper `krema::applyScreenPinFromEnv()` (`src/utils/screenpin.h`): pins a layer-shell window to the output named by the `KREMA_SCREEN` environment variable (e.g. `KREMA_SCREEN=DP-1`).
- Applied to both the dock window (`WaylandDockPlatform::setupWindow`) and the preview popup (`PreviewController::initialize`) — the preview surface is pre-shown full-width, so it is just as important that it sits on the right output.
- No behavior change when the variable is unset.

One subtlety worth noting: setting only `QWindow::setScreen()` is **not** sufficient — the surface still ends up wherever the compositor decides. Both the `LayerShellQt::Window::setScreen()` and `setWantsToBeOnActiveScreen(false)` calls are required for KWin to honor the requested output.

## Testing

Tested on Garuda Linux (Arch), KDE Plasma 6.7.3 / KWin Wayland, Qt 6, 3×2560x1440 monitors (DP-1/DP-2/DP-3):
- Without `KREMA_SCREEN`: unchanged behavior (dock on the first output).
- With `KREMA_SCREEN=DP-1`: dock and preview both created on DP-1 (verified via KWin scripting `workspace.windowList()`), auto-hide/dodge and previews working normally.
- With a non-existent name: falls through to unchanged behavior.

I realize per-screen settings are on the roadmap — this is meant as a minimal escape hatch until that lands. Happy to rework it as a proper config entry (`kcfg`) instead if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
