### PR TITLE
fix: resolve app icons on Wayland when no matching .desktop file exists

### DIFF
--- a/src/models/dockmodel.cpp
+++ b/src/models/dockmodel.cpp
@@ -3,6 +3,8 @@
 
 #include "dockmodel.h"
 
+#include "taskiconprovider.h"
+
 #include <taskmanager/abstracttasksmodel.h>
 #include <taskmanager/tasksmodel.h>
 
@@ -10,6 +12,7 @@
 #include <QIcon>
 #include <QLoggingCategory>
 #include <QScreen>
+#include <QSet>
 
 Q_LOGGING_CATEGORY(lcModel, "krema.model")
 
@@ -123,7 +126,43 @@ QString DockModel::iconName(int index) const
     }
 
     const QIcon icon = idx.data(Qt::DecorationRole).value<QIcon>();
-    return icon.name();
+    QString name = icon.name();
+
+    // Icons resolved from an absolute file path (Snap/Flatpak/AppImage .desktop
+    // entries commonly use Icon=/path/to/icon.png instead of a theme name) have
+    // no QIcon::name(). Register the actual pixmap under a synthetic key so
+    // TaskIconProvider can still find and normalize it, instead of silently
+    // falling back to the dock's generic letter-tile placeholder.
+    if (name.isEmpty() && !icon.isNull()) {
+        name = QStringLiteral("raw:") + appId(index);
+        TaskIconProvider::registerRawIcon(name, icon);
+    }
+
+    // KWin/LibTaskManager hand back a generic placeholder icon (name "wayland")
+    // for windows it can't otherwise identify, instead of leaving the
+    // decoration null. It resolves to a real (but meaningless) theme icon, so
+    // it isn't caught by the empty-or-unresolvable check below — treat it the
+    // same as having no icon at all.
+    static const QSet<QString> genericPlaceholderIconNames{QStringLiteral("wayland"), QStringLiteral("unknown")};
+    if (genericPlaceholderIconNames.contains(name)) {
+        name.clear();
+    }
+
+    // Whenever we still don't have a theme name that actually resolves to a
+    // real icon — no decoration at all (common on Wayland when no installed
+    // .desktop file matches the window's app_id), or a name LibTaskManager
+    // handed back that doesn't correspond to anything installed — fall back
+    // to the window's app_id itself. Many toolkits (Flutter apps in
+    // particular) name their installed icon after their app_id, even when no
+    // matching .desktop file exists to supply Icon= directly.
+    if (name.isEmpty() || (!name.startsWith(QLatin1String("raw:")) && QIcon::fromTheme(name).isNull())) {
+        const QString app = appId(index);
+        if (!app.isEmpty() && !QIcon::fromTheme(app).isNull()) {
+            name = app;
+        }
+    }
+
+    return name;
 }
 
 QUrl DockModel::launcherUrl(int index) const

--- a/src/models/taskiconprovider.cpp
+++ b/src/models/taskiconprovider.cpp
@@ -12,10 +12,17 @@
 namespace krema
 {
 
+QHash<QString, QIcon> TaskIconProvider::s_rawIcons;
+
 TaskIconProvider::TaskIconProvider(bool normalizationEnabled)
     : QQuickImageProvider(QQuickImageProvider::Pixmap)
     , m_normalizationEnabled(normalizationEnabled)
 {
+}
+
+void TaskIconProvider::registerRawIcon(const QString &key, const QIcon &icon)
+{
+    s_rawIcons.insert(key, icon);
 }
 
 QPixmap TaskIconProvider::requestPixmap(const QString &id, QSize *size, const QSize &requestedSize)
@@ -28,7 +35,13 @@ QPixmap TaskIconProvider::requestPixmap(const QString &id, QSize *size, const QS
     const int height = requestedSize.height() > 0 ? requestedSize.height() : 48;
     const int targetSize = std::max(width, height);
 
-    QIcon icon = QIcon::fromTheme(iconName);
+    // Icons resolved from an absolute file path (Snap/Flatpak/AppImage .desktop
+    // entries commonly do this) have no theme name, so DockModel registers them
+    // here under a synthetic key instead of a QIcon::fromTheme()-resolvable name.
+    QIcon icon = s_rawIcons.value(iconName);
+    if (icon.isNull()) {
+        icon = QIcon::fromTheme(iconName);
+    }
     if (icon.isNull()) {
         icon = QIcon(iconName);
     }

--- a/src/models/taskiconprovider.h
+++ b/src/models/taskiconprovider.h
@@ -45,6 +45,12 @@ public:
     void setIconScale(qreal scale);
     void clearCache();
 
+    /// Register a QIcon that has no theme name (e.g. resolved from an absolute
+    /// file path, as with Snap/Flatpak/AppImage .desktop entries) under a
+    /// synthetic key so requestPixmap() can still find it. Runs on the GUI
+    /// thread only (QQuickImageProvider::Pixmap providers are not threaded).
+    static void registerRawIcon(const QString &key, const QIcon &icon);
+
 private:
     /// Find the bounding rect of non-transparent content in an image.
     static QRect findContentBounds(const QImage &image, int threshold = 25);
@@ -61,6 +67,8 @@ private:
     QHash<QString, IconNormalizationInfo> m_cache;
     bool m_normalizationEnabled = true;
     qreal m_iconScale = 1.0;
+
+    static QHash<QString, QIcon> s_rawIcons;
 
     static constexpr int kAlphaThreshold = 25;
     static constexpr qreal kMinContentRatio = 0.92;

--- a/src/qml/DockItem.qml
+++ b/src/qml/DockItem.qml
@@ -429,6 +429,13 @@ Item {
             // Without this, the binding only tracks dockItem.index and won't
             // re-evaluate when different data appears at the same position.
             let _dep = model.display
+            // Also depend on model.decoration: LibTaskManager resolves a
+            // window's icon asynchronously after the row is first inserted
+            // (title/appId can already be known before the icon is). Without
+            // this, a window opened while the dock is already running keeps
+            // whatever (possibly empty) icon name was computed at creation,
+            // even after the real icon becomes available moments later.
+            let _dep2 = model.decoration
             let name = DockModel.iconName(dockItem.index)
             if (name && name.length > 0) {
                 return "image://icon/" + name + "?v=" + DockView.iconCacheVersion


### PR DESCRIPTION
## Summary

Two related bugs cause app icons to fall back to the dock's generic letter-tile placeholder instead of the real icon. Both show up in practice with Snap-packaged apps (VS Code and LocalSend).

1. **Absolute-path icons have no `QIcon::name()`.** Snap/Flatpak/AppImage `.desktop` entries commonly use `Icon=/path/to/icon.png` instead of a theme name. `DockModel::iconName()` was returning an empty string even though LibTaskManager had already loaded a perfectly good `QIcon` for that window. The actual pixmap data was sitting right there, just discarded because it had no theme name. `TaskIconProvider` now accepts these through a small raw-icon registry keyed by a synthetic name (`raw:<appId>`), so they get normalized and sized the same way as every other icon instead of being skipped.

2. **KWin hands back a generic `"wayland"` placeholder icon**, not a null decoration, when no installed `.desktop` file matches a window's `app_id`. This is common on Wayland for Flutter/GTK apps that don't ship one (LocalSend is one). Because `"wayland"` is a real, resolvable theme icon, the existing empty/unresolvable check didn't catch it. `DockModel` now treats this sentinel the same as no icon at all, and falls back to trying the window's `app_id` directly as a theme icon name. Many toolkits, Flutter apps especially, name their installed icon after their `app_id` per the freedesktop convention, even when there's no matching `.desktop` file to supply `Icon=`.

There's also a related QML fix here: the icon `Image`'s `source` binding only depended on `model.display` (the title), so a window opened after the dock was already running could get stuck with whatever icon was known at delegate-creation time. LibTaskManager resolves icons asynchronously, and nothing told the binding to re-evaluate once the real one showed up a moment later. It now also depends on `model.decoration`.

## Before / after

VS Code and LocalSend both used to render as a solid colored square with a letter on it instead of their actual icon. Both now show the real icon, normalized and sized to match the rest of the dock.

## Test plan
- [x] VS Code (Snap, absolute-path `Icon=`) now shows its real icon
- [x] LocalSend (Snap, no matching `.desktop`, generic `"wayland"` decoration) now shows its real icon, including when opened after the dock is already running
- [x] Checked for regressions on apps that already resolved correctly (Dolphin, Chrome, Konsole, System Settings) with a standalone `QIcon`/`TaskIconProvider` test harness plus live dock testing
- [x] Built via CMake/Ninja against Qt 6.10 / KF6 6.24 on Ubuntu 26.04 (BUILD_TESTING=OFF, Catch2 not available)
